### PR TITLE
Added check over the .inp/.dat/.plt files extensions

### DIFF
--- a/tugui/main.py
+++ b/tugui/main.py
@@ -911,7 +911,7 @@ class TuPostProcessingGui(BaseWindow):
     if not filenames: return
     # Check if the selected file has the correct extension
     for files in filenames:
-      if not files.endswith('.dat') or not files.endswith('.plt'):
+      if not files.endswith('.dat') and not files.endswith('.plt'):
         messagebox.showerror("Error", "Error: one of the selected files has not the correct 'dat' or 'plt' extension.")
 
     # Store the selected files as an instance attribute


### PR DESCRIPTION
A message box has been added to be shown whenever users try to load a file not having the correct .inp/.dat/.plt extension.