### PR TITLE
Display error when no output plot files are generated

### DIFF
--- a/tugui/main.py
+++ b/tugui/main.py
@@ -260,37 +260,43 @@ class TuPostProcessingGui(tk.Tk):
     # The tab can span 2 columns so to overlap with the following button
     self.plotTabControl.grid(column=0, row=1, columnspan=2, sticky='nsew')
 
-    # Instantiate the class that read and extract the content of the .inp file
-    # in order to know how many diagrams need to be produced
-    inpreader = InpHandler(self.loaded_inp_file)
-    # Read the loaded .inp file and extract its content
-    inpreader.read_inp_file()
-    # Save the content of the read .inp file into a file whose name complies with
-    # what needed by the plotting executables
-    self.loaded_inp_file = inpreader.save_loaded_inp()
+    try:
+      # Instantiate the class that read and extract the content of the .inp file
+      # in order to know how many diagrams need to be produced
+      inpreader = InpHandler(self.loaded_inp_file)
+      # Read the loaded .inp file and extract its content
+      inpreader.read_inp_file()
+      # Save the content of the read .inp file into a file whose name complies with
+      # what needed by the plotting executables
+      self.loaded_inp_file = inpreader.save_loaded_inp()
 
-    # Handle the TuPlot and TuStat plot cases differently
-    if inpreader.diagrams_list[0].is_tuplot:
-      # Get the path to the TuPlot executable
-      executable_path = self.guiconfig.tuplot_path
-      # Set the default name of the files the plotting executable will create
-      output_files_name = "TuPlot"
-    else:
-      # Get the path to the TuStat executable
-      executable_path = self.guiconfig.tustat_path
-      # Set the default name of the files the plotting executable will create
-      output_files_name = "TuStat"
+      # Handle the TuPlot and TuStat plot cases differently
+      if inpreader.diagrams_list[0].is_tuplot:
+        # Get the path to the TuPlot executable
+        executable_path = self.guiconfig.tuplot_path
+        # Set the default name of the files the plotting executable will create
+        output_files_name = "TuPlot"
+      else:
+        # Get the path to the TuStat executable
+        executable_path = self.guiconfig.tustat_path
+        # Set the default name of the files the plotting executable will create
+        output_files_name = "TuStat"
 
-    # Run the method that deals with instantiating the dataclass storing the needed
-    # information for the plotting executable to be run. The corresponding executable
-    # is run afterwards and the paths to the output .dat and .plt files, stored in the
-    # returned object, are updated.
-    inp_to_dat = DatGenerator.init_DatGenerator_and_run_exec(
-      plotexec_path=executable_path,
-      inp_path=self.loaded_inp_file,
-      plots_num=len(inpreader.diagrams_list),
-      cwd=self.output_dir,
-      output_files_name=output_files_name)
+      # Run the method that deals with instantiating the dataclass storing
+      # the needed information for the plotting executable to be run. The
+      # corresponding executable is run afterwards and the paths to the output
+      # .dat and .plt files, stored in the returned object, are updated.
+      inp_to_dat = DatGenerator.init_DatGenerator_and_run_exec(
+        plotexec_path=executable_path,
+        inp_path=self.loaded_inp_file,
+        plots_num=len(inpreader.diagrams_list),
+        cwd=self.output_dir,
+        output_files_name=output_files_name)
+    except Exception as e:
+      # Intercept any exception produced while reading/saving the .inp file
+      # or while running the plotting executable and show a pop-up message
+      messagebox.showerror("Error", type(e).__name__ + "–" + str(e))
+      raise RuntimeError(e)
 
     # For each diagram configuration create a new PlotFigure object and plot the curves
     for i in range(0, len(inpreader.diagrams_list)):

--- a/tugui/support.py
+++ b/tugui/support.py
@@ -1,3 +1,5 @@
+import os
+
 from enum import Enum
 from typing import Tuple
 
@@ -45,3 +47,24 @@ class IANT(Enum):
     Descriptive string of the element of the enumeration
     """
     return self.value[1]
+
+def get_file_modification_time(file_path: str) -> float | None:
+  """
+  Function that returns the last modification time of the file whose
+  path is given as input.
+
+  Parameters
+  ----------
+  file_path : str
+      The path of the file whose last modification time has to be
+      retrieved
+
+  Returns
+  -------
+  The file last modification time, if exists; None otherwise.
+  """
+  try:
+      return os.path.getmtime(file_path)
+  except OSError:
+      # If the file does not exist, an OSError is caught
+      return None


### PR DESCRIPTION
So far, if any problem in the generation of the output plot files happened, no error message was shown to the user if the output folder already had plot files with the same names. 
This could happen either when configuring the plot from the GUI or when loading an invalid .inp file.
The issue has been addressed by checking the last modification time of the output files: now, if no change in the last modification time occurs, an exception is raised and a pop-up message is displayed.