### PR TITLE
Setting output folder and displaying this information

### DIFF
--- a/tugui/main.py
+++ b/tugui/main.py
@@ -1019,6 +1019,9 @@ class TuPostProcessingGui(tk.Tk):
     self.status_bar.set_text("")
     # Re-build the plot tabs
     self.build_tabs_area()
+    # Delete the output directory attribute, if any
+    if hasattr(self, 'output_dir'):
+      delattr(self, 'output_dir')
 
 
 def new_postprocessing(event: Union[tk.Event, None] = None) -> None:

--- a/tugui/main.py
+++ b/tugui/main.py
@@ -362,13 +362,11 @@ class TuPostProcessingGui(tk.Tk):
       self.plireader = PliReader.init_PliReader(self.pli_entry.var.get())
       print("Path to the .pli file: " + self.plireader.pli_path)
 
-      # Update the default directory of the file selection window to the one of
-      # the currently opened file
-      self.initial_dir = os.path.dirname(self.plireader.pli_path)
-      # If not already done, set the output directory to the one of the
-      # currently opened file
-      self.__set_output_dir_and_status_message(
-        "Selected .pli file: " + self.plireader.pli_path)
+      # Update the default directory of the file selection window and, if not
+      # already done, set the output directory to the one of the currently
+      # opened file
+      self.__set_directories_and_status_message(
+        self.plireader.pli_path, "Selected .pli file: ")
 
       # Instantiate the MacReader class
       self.macreader = MacReader(
@@ -818,13 +816,11 @@ class TuPostProcessingGui(tk.Tk):
 
     # Store the selected file as an instance attribute
     self.loaded_inp_file = filename
-    # Update the default directory of the file selection window to the one of
-    # the currently opened file
-    self.initial_dir = os.path.dirname(filename)
-    # If not already done, set the output directory to the one of the
-    # currently opened file
-    self.__set_output_dir_and_status_message(
-      "Loaded .inp file: " + self.loaded_inp_file)
+    # Update the default directory of the file selection window and, if not
+    # already done, set the output directory to the one of the currently
+    # opened file
+    self.__set_directories_and_status_message(
+      self.loaded_inp_file, "Loaded .inp file: ")
 
     # Generate the '<<InpLoaded>>' virtual event
     self.event_generate('<<InpLoaded>>')
@@ -1012,24 +1008,35 @@ class TuPostProcessingGui(tk.Tk):
     if hasattr(self, 'output_dir'):
       delattr(self, 'output_dir')
 
-  def __set_output_dir_and_status_message(self, first_text: str) -> None:
+  def __set_directories_and_status_message(
+      self, file_name: str, first_text: str) -> None:
     """
-    Method that updates the output directory with the one of the currently
-    loaded .pli or .inp file, if not already set directly by the user.
+    Method that updates the default directory of the file selection window
+    with the one of the currently loaded .pli or .inp file.
+    The same is performed for the output directory, if it has not already
+    been set directly by the user.
     A descriptive message is assembled by prefixing it with the given string
     and indicating the path of the output folder.
     The status bar widget is updated with the assembled text.
 
     Parameters
     ----------
+    file_name : str
+      The path of the selected file.
     first_text : str
       The first part of the text message shown in the status bar widget.
     """
+    # Update the default directory of the file selection window to the one of
+    # the currently opened file
+    self.initial_dir = os.path.dirname(file_name)
+    # If not already done, set the output directory to the one of the
+    # currently opened file
     if not hasattr(self, 'output_dir') or not self.__is_dir_directly_set:
       self.output_dir = self.initial_dir
 
     # Provide a message to the status bar and to the log file
-    output_message = first_text + ", Output folder: " + self.output_dir
+    output_message = (first_text + file_name + ", Output folder: "
+                      + self.output_dir)
     self.status_bar.set_text(output_message)
     # FIXME: to print into log file
     print(output_message)

--- a/tugui/main.py
+++ b/tugui/main.py
@@ -35,6 +35,10 @@ class TuPostProcessingGui(tk.Tk):
   . the plot area (right side) where the selected curves are shown
   . a status bar (bottom window) showing log messages.
   """
+
+  # Flag stating if the output directory has been set directly
+  __is_dir_directly_set: bool = False
+
   def __init__(self, window_title: str, width: int, height: int) -> None:
     """
     App windows's constructor
@@ -357,6 +361,21 @@ class TuPostProcessingGui(tk.Tk):
       # Extract the information from the .pli file and instantiate the 'PliReader' class
       self.plireader = PliReader.init_PliReader(self.pli_entry.var.get())
       print("Path to the .pli file: " + self.plireader.pli_path)
+
+      # Update the default directory of the file selection window to the one of
+      # the currently opened file
+      self.initial_dir = os.path.dirname(self.plireader.pli_path)
+      # If not already done, set the output directory to the one of the
+      # currently opened file
+      if not hasattr(self, 'output_dir') or not self.__is_dir_directly_set:
+        self.output_dir = self.initial_dir
+
+      # Provide a message to the status bar and to the log file
+      output_message = "Selected .pli file: " + self.plireader.pli_path + \
+          ", Output folder: " + self.output_dir
+      self.status_bar.set_text(output_message)
+      # FIXME: to print into log file
+      print(output_message)
 
       # Instantiate the MacReader class
       self.macreader = MacReader(
@@ -774,6 +793,16 @@ class TuPostProcessingGui(tk.Tk):
 
     # Update the output directory to the one currently selected
     self.output_dir = foldername
+    # Update the output directory to the one currently selected
+    self.__is_dir_directly_set = True
+
+    # Provide a message to the status bar and to the log file
+    mssg = self.status_bar.label.cget('text').split(',')
+    if mssg[0]:
+        output_message = mssg[0] + ", Output folder: " + self.output_dir
+    else:
+        output_message = "Selected output folder: " + self.output_dir
+    self.status_bar.set_text(output_message)
 
     print("Selected output folder:", self.output_dir)
 
@@ -796,11 +825,17 @@ class TuPostProcessingGui(tk.Tk):
 
     # Store the selected file as an instance attribute
     self.loaded_inp_file = filename
-    # Change the start directory for the file selection window
+    # Update the default directory of the file selection window to the one of
+    # the currently opened file
     self.initial_dir = os.path.dirname(filename)
-
+    # If not already done, set the output directory to the one of the
+    # currently opened file
+    if not hasattr(self, 'output_dir') or not self.__is_dir_directly_set:
+      self.output_dir = self.initial_dir
     # Provide a message to the status bar
-    self.status_bar.set_text("Selected .inp file: " + self.loaded_inp_file)
+    output_message = "Loaded .inp file: " + self.loaded_inp_file + \
+        ", Output folder: " + self.output_dir
+    self.status_bar.set_text(output_message)
 
     # Generate the '<<InpLoaded>>' virtual event
     self.event_generate('<<InpLoaded>>')

--- a/tugui/main.py
+++ b/tugui/main.py
@@ -367,15 +367,8 @@ class TuPostProcessingGui(tk.Tk):
       self.initial_dir = os.path.dirname(self.plireader.pli_path)
       # If not already done, set the output directory to the one of the
       # currently opened file
-      if not hasattr(self, 'output_dir') or not self.__is_dir_directly_set:
-        self.output_dir = self.initial_dir
-
-      # Provide a message to the status bar and to the log file
-      output_message = "Selected .pli file: " + self.plireader.pli_path + \
-          ", Output folder: " + self.output_dir
-      self.status_bar.set_text(output_message)
-      # FIXME: to print into log file
-      print(output_message)
+      self.__set_output_dir_and_status_message(
+        "Selected .pli file: " + self.plireader.pli_path)
 
       # Instantiate the MacReader class
       self.macreader = MacReader(
@@ -830,12 +823,8 @@ class TuPostProcessingGui(tk.Tk):
     self.initial_dir = os.path.dirname(filename)
     # If not already done, set the output directory to the one of the
     # currently opened file
-    if not hasattr(self, 'output_dir') or not self.__is_dir_directly_set:
-      self.output_dir = self.initial_dir
-    # Provide a message to the status bar
-    output_message = "Loaded .inp file: " + self.loaded_inp_file + \
-        ", Output folder: " + self.output_dir
-    self.status_bar.set_text(output_message)
+    self.__set_output_dir_and_status_message(
+      "Loaded .inp file: " + self.loaded_inp_file)
 
     # Generate the '<<InpLoaded>>' virtual event
     self.event_generate('<<InpLoaded>>')
@@ -1022,6 +1011,28 @@ class TuPostProcessingGui(tk.Tk):
     # Delete the output directory attribute, if any
     if hasattr(self, 'output_dir'):
       delattr(self, 'output_dir')
+
+  def __set_output_dir_and_status_message(self, first_text: str) -> None:
+    """
+    Method that updates the output directory with the one of the currently
+    loaded .pli or .inp file, if not already set directly by the user.
+    A descriptive message is assembled by prefixing it with the given string
+    and indicating the path of the output folder.
+    The status bar widget is updated with the assembled text.
+
+    Parameters
+    ----------
+    first_text : str
+      The first part of the text message shown in the status bar widget.
+    """
+    if not hasattr(self, 'output_dir') or not self.__is_dir_directly_set:
+      self.output_dir = self.initial_dir
+
+    # Provide a message to the status bar and to the log file
+    output_message = first_text + ", Output folder: " + self.output_dir
+    self.status_bar.set_text(output_message)
+    # FIXME: to print into log file
+    print(output_message)
 
 
 def new_postprocessing(event: Union[tk.Event, None] = None) -> None:


### PR DESCRIPTION
Previously, if not set directly by the menu bar option, the output folder was assigned to the one of the firstly loaded _.pli_ file. If any other file was opened, this directory did not change anymore. In addition, there was no indication for the user about this behaviour. 
Now, if not directly set, the output folder is always assigned to the directory of the currently loaded _.pli_ or _.inp_ file. 
The status bar used to show the path of the loaded file only; now it also shows the path of the output folder.
If the output folder is set directly, it will remain fixed for any subsequent _.pli_ or _.inp_ file loaded.
Resetting the GUI will also clear the output folder path.