### PR TITLE
Wrong Number of Slices and Times

### DIFF
--- a/tugui/tu_interface.py
+++ b/tugui/tu_interface.py
@@ -201,7 +201,7 @@ class InpHandler():
       check_file_existence(os.path.join(self.inp_dir, plireader.mac_path), 'mac')
       check_file_existence(os.path.join(self.inp_dir, plireader.mic_path), 'mic')
       # Check the .sta file existence only if required, i.e if the 'ISTATI' field is '1'
-      if plireader.opt_dict['ISTATI'] == 1:
+      if int(plireader.opt_dict['ISTATI']):
         check_file_existence(os.path.join(self.inp_dir, plireader.sta_path), 'sta')
 
     # Declare a string holding the .inp filename (with default to 'TuPlot')
@@ -509,7 +509,7 @@ class PliReader():
             pli_reader.sta_dataset = f.readline().split()[0]
 
     # Extract the number of axial sections depending on the ISLICE field
-    if pli_reader.opt_dict['ISLICE'] == '1':
+    if int(pli_reader.opt_dict['ISLICE']):
       pli_reader.axial_steps = int(pli_reader.opt_dict['M3'])
     else:
       pli_reader.axial_steps = int(pli_reader.opt_dict['M3']) + 1

--- a/tugui/tu_interface.py
+++ b/tugui/tu_interface.py
@@ -509,7 +509,7 @@ class PliReader():
             pli_reader.sta_dataset = f.readline().split()[0]
 
     # Extract the number of axial sections depending on the ISLICE field
-    if pli_reader.opt_dict['ISLICE'] == 1:
+    if pli_reader.opt_dict['ISLICE'] == '1':
       pli_reader.axial_steps = int(pli_reader.opt_dict['M3'])
     else:
       pli_reader.axial_steps = int(pli_reader.opt_dict['M3']) + 1


### PR DESCRIPTION
The `init_PliReader()` static method of the `PliReader` class has been updated in the way it extracts the number of slices from the .pli file. This is done by reading the `ISLICE` value as a string; however, previously, it was compared with an integer value, thus preventing to correctly identify the number of slices. 
Now, the `ISLICE` value is transformed into an integer to check if "truthy" or not: this solves the highlighted issue. 
In addition, by properly identifying the number of slices, also the problem on the missing time instants for the radially dependent quantities is solved; in fact, the extraction of these times from the _.mac_ file is directly tied to the number of slices.